### PR TITLE
Split React rendering of KPIs to each individual box.

### DIFF
--- a/src/components/KpiReact/kpi.js
+++ b/src/components/KpiReact/kpi.js
@@ -31,25 +31,19 @@ const Kpi = ({
     }
   }, [chartName, isActive]);
   return (
-    <div
-      className="kpi-box"
-      id={`kpi-${id}`}
-      data-tippy-i18n={isActive ? "kpi-active-tooltip" : null}
-      data-tippy-placement={isActive ? "bottom" : null}
-      data-tippy-content={
-        isActive ? "Confirmed cases minus recovered minus deceased" : null
-      }
-    >
-      <div className="label">
-        {label}
-        {isActive && <span>&#9432;</span>}
+    <>
+      <div className="vitals">
+        <div className="label">
+          {label}
+          {isActive && <span>&#9432;</span>}
+        </div>
+        <div className="value">{value} </div>
+        <div className="diff">( {diff} )</div>
+        <div
+          className="description"
+          dangerouslySetInnerHTML={{ __html: percent }}
+        ></div>
       </div>
-      <div className="value">{value} </div>
-      <div className="diff">( {diff} )</div>
-      <div
-        className="description"
-        dangerouslySetInnerHTML={{ __html: percent }}
-      ></div>
       <Loader isLoaded={isLoading} />
       {graph && (
         <div
@@ -68,7 +62,7 @@ const Kpi = ({
           }}
         ></p>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,157 @@
       </div>
     </header>
   
-    <section id="kpi"></section>
+    <section id="kpi">
+      <div class="kpi-box" id="kpi-confirmed">
+        <div class="label" data-i18n="kpi-confirmed">Confirmed</div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+        <svg
+          style="width: 0; height: 0; position: absolute;"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <linearGradient id="kpi-confirmed-chart-gradient" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(244,67,54, 0.6)" />
+            <stop offset="90%" stop-color="rgba(244,67,54, 0)" />
+            <stop offset="100%" stop-color="rgba(244,67,54, 0)" />
+          </linearGradient>
+        </svg>
+        <div class="chart" id="kpi-confirmed-chart"></div>
+        <div class="chart-caption" data-i18n="confirmed-chart-caption">
+          Confirmed cases per day
+        </div>
+      </div>
+
+      <div class="kpi-box" id="kpi-recovered">
+        <div class="label" data-i18n="kpi-recovered">Recovered</div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+        <svg
+          style="width: 0; height: 0; position: absolute;"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <linearGradient id="kpi-recovered-chart-gradient" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(24,118,211, 0.6)" />
+            <stop offset="90%" stop-color="rgba(24,118,211, 0)" />
+            <stop offset="100%" stop-color="rgba(24,118,211, 0)" />
+          </linearGradient>
+        </svg>
+        <div class="chart" id="kpi-recovered-chart"></div>
+        <div class="chart-caption" data-i18n="recovered-chart-caption">
+          Recoveries per day
+        </div>
+      </div>
+
+      <div class="kpi-box" id="kpi-critical">
+        <div class="label" data-i18n="kpi-critical">Critical</div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+        <svg
+          style="width: 0; height: 0; position: absolute;"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <linearGradient id="kpi-critical-chart-gradient" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(114,4,5, 0.6)" />
+            <stop offset="90%" stop-color="rgba(114,4,5, 0)" />
+            <stop offset="100%" stop-color="rgba(114,4,5, 0)" />
+          </linearGradient>
+        </svg>
+        <div class="chart" id="kpi-critical-chart"></div>
+        <div class="chart-caption" data-i18n="critical-chart-caption">
+          Critical patients per day
+        </div>
+      </div>
+
+      <div class="kpi-box" id="kpi-deceased">
+        <div class="label" data-i18n="kpi-deceased">Deaths</div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+        <svg
+          style="width: 0; height: 0; position: absolute;"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <linearGradient id="kpi-deceased-chart-gradient" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(54,72,79, 0.6)" />
+            <stop offset="90%" stop-color="rgba(54,72,79, 0)" />
+            <stop offset="100%" stop-color="rgba(54,72,79, 0)" />
+          </linearGradient>
+        </svg>
+        <div class="chart" id="kpi-deceased-chart"></div>
+        <div class="chart-caption" data-i18n="deceased-chart-caption">
+          Deaths per day
+        </div>
+      </div>
+
+      <div
+        class="kpi-box"
+        id="kpi-active"
+        data-tippy-i18n="kpi-active-tooltip"
+        data-tippy-placement="bottom"
+      >
+        <div class="label">
+          <span data-i18n="kpi-active">Active</span> &#9432;
+        </div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+        <svg
+          style="width: 0; height: 0; position: absolute;"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <linearGradient id="kpi-active-chart-gradient" x2="0" y2="1">
+            <stop offset="0%" stop-color="rgba(223,14,31, 0.6)" />
+            <stop offset="90%" stop-color="rgba(223,14,31, 0)" />
+            <stop offset="100%" stop-color="rgba(223,14,31, 0)" />
+          </linearGradient>
+        </svg>
+        <div class="chart" id="kpi-active-chart"></div>
+        <div class="chart-caption" data-i18n="active-chart-caption">
+          Active cases per day
+        </div>
+      </div>
+
+      <div class="kpi-box" id="kpi-tested">
+        <div class="vitals">
+          <div class="label" data-i18n="kpi-tested">Tested</div>
+          <div class="value"><div class="lds-dual-ring"></div></div>
+          <div class="diff">&nbsp;</div>
+          <div class="description"></div>
+        </div>
+        <div class="chart-container">
+          <svg
+            style="width: 0; height: 0; position: absolute;"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <linearGradient id="kpi-tested-chart-gradient" x2="0" y2="1">
+              <stop offset="0%" stop-color="rgba(164,173,192, 0.6)" />
+              <stop offset="90%" stop-color="rgba(164,173,192, 0)" />
+              <stop offset="100%" stop-color="rgba(164,173,192, 0)" />
+            </linearGradient>
+          </svg>
+          <div class="chart" id="kpi-tested-chart"></div>
+          <div class="chart-caption" data-i18n="tested-chart-caption">
+            Tests per day
+          </div>
+        </div>
+      </div>
+
+      <div class="kpi-box" id="kpi-critical-short">
+        <div class="label" data-i18n="kpi-critical">Critical</div>
+        <div class="value"><div class="lds-dual-ring"></div></div>
+        <div class="diff">&nbsp;</div>
+        <div class="description"></div>
+      </div>
+    </section>
 
     <section id="national-charts" class="embed-hide">
       <section id="trend-chart-container" class="embed-hide">

--- a/src/index.js
+++ b/src/index.js
@@ -259,8 +259,19 @@ const loadDataOnPage = () => {
       PAGE_STATE.dataLoaded = ddb.isLoaded();
 
       //rendering the react component as soon as the data loads
-      const wrapper = document.getElementById("kpi");
-      ReactDOM.render(<KpiContainer data={ddb} />, wrapper);
+      // const wrapper = document.getElementById("kpi");
+      // ReactDOM.render(<KpiContainer data={ddb} />, wrapper);
+      [
+        "confirmed",
+        "recovered",
+        "critical",
+        "deceased",
+        "active",
+        "tested",
+      ].forEach((type) => {
+        const wrapper = document.getElementById(`kpi-${type}`);
+        ReactDOM.render(<KpiContainer data={ddb} type={type} />, wrapper);
+      });
 
       const event = new CustomEvent("covid19japan-redraw");
       document.dispatchEvent(event);


### PR DESCRIPTION
Splitting the rendering of the `#kpi` to each individual `kpi-${type}` seems to remove the wobble and flicker.